### PR TITLE
Revert switch to the production bucket

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -21,7 +21,8 @@ module "api" {
   django_cors_origin_regex_whitelist = ["^https:\\/\\/[0-9a-z\\-]+--gui-dandiarchive-org\\.netlify\\.app$"]
 
   additional_django_vars = {
-    DJANGO_DANDI_DANDISETS_BUCKET_NAME = aws_s3_bucket.sponsored_bucket.id
+    # DJANGO_DANDI_DANDISETS_BUCKET_NAME = aws_s3_bucket.sponsored_bucket.id
+    DJANGO_DANDI_DANDISETS_BUCKET_NAME = aws_s3_bucket.api_dandisets_bucket.id
     DJANGO_DANDI_SCHEMA_VERSION        = "0.1.0"
     DJANGO_DANDI_GIRDER_API_URL        = "https://girder.dandiarchive.org/api/v1"
     DJANGO_DANDI_DOI_API_URL           = "https://api.test.datacite.org/dois"


### PR DESCRIPTION
After switching to the production bucket, any S3 operations return:
```
Mar 29 18:04:00 dandi-api app/web.1                     botocore.exceptions.ClientError: An error                   
Mar 29 18:04:00 dandi-api app/web.1                     occurred (AccessDenied) when calling the                    
Mar 29 18:04:00 dandi-api app/web.1                     PutObject operation: Access Denied                          
```
This reverts that switch so that the app is still usable while we diagnose.