### PR TITLE
Sponsored bucket permissions

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -56,6 +56,8 @@ data "aws_iam_policy_document" "api_dandisets_bucket" {
     resources = [
       aws_s3_bucket.api_dandisets_bucket.arn,
       "${aws_s3_bucket.api_dandisets_bucket.arn}/*",
+      aws_s3_bucket.sponsored_bucket.arn,
+      "${aws_s3_bucket.sponsored_bucket.arn}/*",
     ]
   }
 }

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -22,7 +22,7 @@ module "api" {
 
   additional_django_vars = {
     # DJANGO_DANDI_DANDISETS_BUCKET_NAME = aws_s3_bucket.sponsored_bucket.id
-    DJANGO_DANDI_DANDISETS_BUCKET_NAME = aws_s3_bucket.api_dandisets_bucket.id
+    DJANGO_DANDI_DANDISETS_BUCKET_NAME = aws_s3_bucket.sponsored_bucket.id
     DJANGO_DANDI_SCHEMA_VERSION        = "0.1.0"
     DJANGO_DANDI_GIRDER_API_URL        = "https://girder.dandiarchive.org/api/v1"
     DJANGO_DANDI_DOI_API_URL           = "https://api.test.datacite.org/dois"

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -36,13 +36,17 @@ module "api" {
   }
 }
 
+data "aws_iam_user" "api" {
+  user_name = module.api.iam_user_id
+}
+
 resource "aws_s3_bucket" "api_dandisets_bucket" {
   bucket = "dandi-api-dandisets-testing"
   acl    = "private"
 }
 
 resource "aws_iam_user_policy" "api_dandisets_bucket" {
-  user   = module.api.iam_user_id
+  user   = data.aws_iam_user.api.id
   name   = "dandi-api-dandiset-bucket"
   policy = data.aws_iam_policy_document.api_dandisets_bucket.json
 }
@@ -119,7 +123,7 @@ data "aws_iam_policy_document" "dandi_girder" {
     }
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.project_account.account_id}:user/${module.api.iam_user_id}"]
+      identifiers = [data.aws_iam_user.api.arn]
     }
   }
 }

--- a/terraform/sponsored_bucket.tf
+++ b/terraform/sponsored_bucket.tf
@@ -116,4 +116,18 @@ data "aws_iam_policy_document" "sponsored_bucket" {
       values   = [aws_s3_bucket.sponsored_bucket.arn]
     }
   }
+
+  statement {
+    sid = "dandi-api"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.project_account.account_id}:user/${module.api.iam_user_id}"]
+    }
+    actions = [
+      "s3:*",
+    ]
+    resources = [
+      "${aws_s3_bucket.sponsored_bucket.arn}/*",
+    ]
+  }
 }

--- a/terraform/sponsored_bucket.tf
+++ b/terraform/sponsored_bucket.tf
@@ -120,8 +120,8 @@ data "aws_iam_policy_document" "sponsored_bucket" {
   statement {
     sid = "dandi-api"
     principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.project_account.account_id}:user/${module.api.iam_user_id}"]
+      type = "AWS"
+      identifiers = [data.aws_iam_user.api.arn,]
     }
     actions = [
       "s3:*",


### PR DESCRIPTION
Give the Heroku IAM user permission to write to the sponsored bucket directly using policies rather than delegating through roles.

I think roles will not cut it for giving the Heroku user access to the sponsored bucket, as they need to be explicitly activated and require a role session.