### PR TITLE
Revert temporary girder redirection

### DIFF
--- a/terraform/girder.tf
+++ b/terraform/girder.tf
@@ -5,9 +5,9 @@ data "local_file" "ssh_public_key" {
 resource "aws_route53_record" "girder" {
   zone_id = aws_route53_zone.dandi.zone_id
   name    = "girder"
-  type    = "CNAME"
+  type    = "A"
   ttl     = "300"
-  records = ["dandiarchive.org"]
+  records = [module.girder_server.ec2_ip]
 }
 
 module "girder_server" {


### PR DESCRIPTION
Revert #56 which redirected girder.dandiarchive.org to www.dandiarchive.org, which broke it intentionally so that people could not use the girder interface to access data.

This will restore girder.dandiarchive.org to it's previous functionality so we can poke around girder post migration before we delete it.