### PR TITLE
Allow AWS staging user to write to staging bucket

### DIFF
--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -29,10 +29,38 @@ module "api_staging" {
   }
 }
 
+data "aws_iam_user" "api_staging" {
+  user_name = module.api_staging.iam_user_id
+}
+
 resource "aws_s3_bucket" "api_staging_dandisets_bucket" {
   bucket = "dandi-api-staging-dandisets"
   acl    = "private"
 }
+
+resource "aws_s3_bucket_policy" "api_staging_dandisets_bucket" {
+  bucket = aws_s3_bucket.api_staging_dandisets_bucket.id
+  policy = data.aws_iam_policy_document.api_staging_dandisets_bucket.json
+}
+
+data "aws_iam_policy_document" "api_staging_dandisets_bucket" {
+  version = "2008-10-17"
+
+  statement {
+    sid = "dandi-api-staging"
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_iam_user.api_staging.arn]
+    }
+    actions = [
+      "s3:*",
+    ]
+    resources = [
+      "${aws_s3_bucket.api_staging_dandisets_bucket.arn}/*",
+    ]
+  }
+}
+
 
 resource "heroku_pipeline" "dandi_pipeline" {
   name = "dandi-pipeline"

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -30,7 +30,7 @@ module "api_staging" {
 }
 
 data "aws_iam_user" "api_staging" {
-  user_name = module.api_staging.iam_user_id
+  user_name = module.api_staging.heroku_iam_user_id
 }
 
 resource "aws_s3_bucket" "api_staging_dandisets_bucket" {


### PR DESCRIPTION
The Heroku AWS staging user was set up with a permission that allowed it
access to the staging bucket, but the staging bucket was not set up to
allow access to the user. This adds the correct policies to the bucket.