### PR TITLE
Add gui-staging.dandiarchive.org

### DIFF
--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -18,6 +18,14 @@ resource "aws_route53_record" "gui" {
   records = ["gui-dandiarchive-org.netlify.com"]
 }
 
+resource "aws_route53_record" "gui-staging" {
+  zone_id = aws_route53_zone.dandi.zone_id
+  name    = "gui-staging"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["gui-staging-dandiarchive-org.netlify.com"]
+}
+
 resource "aws_route53_record" "www" {
   zone_id = aws_route53_zone.dandi.zone_id
   name    = "www"


### PR DESCRIPTION
Netlify staging server is up: https://gui-staging-dandiarchive-org.netlify.app/#/ but the URL is unwieldy, so I'm adding a CNAME for https://gui-staging.dandiarchive.org/#/.