### PR TITLE
Specify the Sentry environment for each deployment

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -29,6 +29,7 @@ module "api" {
     DJANGO_DANDI_DOI_API_USER            = "dartlib.dandi"
     DJANGO_DANDI_DOI_API_PREFIX          = "10.80507"
     DJANGO_SENTRY_DSN                    = "https://4bd48b5174ea4b42a130e63ebe3d60d2@o308436.ingest.sentry.io/5266078"
+    DJANGO_SENTRY_ENVIRONMENT            = "production"
   }
   additional_sensitive_django_vars = {
     DJANGO_DANDI_DOI_API_PASSWORD = var.doi_api_password

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -24,6 +24,7 @@ module "api_staging" {
     DJANGO_DANDI_DOI_API_USER            = "dartlib.dandi"
     DJANGO_DANDI_DOI_API_PREFIX          = "10.80507"
     DJANGO_SENTRY_DSN                    = "https://4bd48b5174ea4b42a130e63ebe3d60d2@o308436.ingest.sentry.io/5266078"
+    DJANGO_SENTRY_ENVIRONMENT            = "staging"
   }
   additional_sensitive_django_vars = {
     DJANGO_DANDI_DOI_API_PASSWORD = var.doi_api_password


### PR DESCRIPTION
Otherwise, both deployments report errors as "production" by default, which is incorrect for the staging deployment.