### PR TITLE
Bump metadata schema to 0.4.1

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -24,7 +24,7 @@ module "api" {
     # DJANGO_DANDI_DANDISETS_BUCKET_NAME = aws_s3_bucket.sponsored_bucket.id
     DJANGO_DANDI_DANDISETS_BUCKET_NAME   = aws_s3_bucket.sponsored_bucket.id
     DJANGO_DANDI_DANDISETS_BUCKET_PREFIX = ""
-    DJANGO_DANDI_SCHEMA_VERSION          = "0.3.1"
+    DJANGO_DANDI_SCHEMA_VERSION          = "0.4.1"
     DJANGO_DANDI_DOI_API_URL             = "https://api.test.datacite.org/dois"
     DJANGO_DANDI_DOI_API_USER            = "dartlib.dandi"
     DJANGO_DANDI_DOI_API_PREFIX          = "10.80507"


### PR DESCRIPTION
This is what will change the official schema version in production. This should only be merged once we are ready for the meditor to use 0.4.1.

This should be merged simultaneously with dandi/dandi-api#323