### PR TITLE
Add MX records to enable email forwarding via ImprovMX

### DIFF
--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -33,3 +33,14 @@ resource "aws_route53_record" "www" {
   ttl     = "300"
   records = ["dandi.github.io"]
 }
+
+resource "aws_route53_record" "email" {
+  zone_id = aws_route53_zone.dandi.zone_id
+  name    = "email"
+  type    = "MX"
+  ttl     = "300"
+  records = [
+    "10 mx1.improvmx.com.",
+    "20 mx2.improvmx.com.",
+  ]
+}


### PR DESCRIPTION
The MX records to add were taken from the ImprovMX console, after I set up (on their end) email forwarding from `[info|help]@dandiarchive.org` to `dandi@mit.edu`.