### PR TITLE
Set DJANGO_DANDI_DOI_PUBLISH in production/staging

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -34,6 +34,7 @@ module "api" {
     DJANGO_DANDI_DOI_API_URL             = "https://api.datacite.org/dois"
     DJANGO_DANDI_DOI_API_USER            = "dartlib.dandi"
     DJANGO_DANDI_DOI_API_PREFIX          = "10.48324"
+    DJANGO_DANDI_DOI_PUBLISH             = "true"
     DJANGO_SENTRY_DSN                    = "https://4bd48b5174ea4b42a130e63ebe3d60d2@o308436.ingest.sentry.io/5266078"
     DJANGO_SENTRY_ENVIRONMENT            = "production"
   }

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -27,6 +27,7 @@ module "api_staging" {
     DJANGO_DANDI_DOI_API_URL             = "https://api.test.datacite.org/dois"
     DJANGO_DANDI_DOI_API_USER            = "dartlib.dandi"
     DJANGO_DANDI_DOI_API_PREFIX          = "10.80507"
+    DJANGO_DANDI_DOI_PUBLISH             = "false"
     DJANGO_SENTRY_DSN                    = "https://4bd48b5174ea4b42a130e63ebe3d60d2@o308436.ingest.sentry.io/5266078"
     DJANGO_SENTRY_ENVIRONMENT            = "staging"
   }


### PR DESCRIPTION
When DJANGO_DANDI_DOI_PUBLISH is set to "true", DOIs generated during
publish have status "findable", which means they cannot be deleted. We
only want that in production.

Takes advantage of https://github.com/dandi/dandi-api/pull/451