### PR TITLE
Add bisweb to CORS whitelist

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -22,7 +22,8 @@ module "api" {
     "https://gui.dandiarchive.org",
     "https://gui-beta-dandiarchive-org.netlify.app",
     "https://codepen.io",
-    "https://cdpn.io"
+    "https://cdpn.io",
+    "https://bioimagesuiteweb.github.io"
   ]
   django_cors_origin_regex_whitelist = ["^https:\\/\\/[0-9a-z\\-]+--gui-dandiarchive-org\\.netlify\\.app$"]
 


### PR DESCRIPTION
so https://bioimagesuiteweb.github.io/webapp/viewer.html?image=https://api.dandiarchive.org/api/assets/d62f3ac5-2a0f-4170-a2d9-37d9bb2085c0/download/ works (datasets 26, 58, 66 have .nii.gz files)

ref: https://github.com/dandi/dandi-api/issues/256