### PR TITLE
Remove codepen.io and bioimagesuiteweb.github.io from allowed CORS origins

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -17,13 +17,10 @@ module "api" {
   heroku_cloudamqp_plan   = "tiger"
   heroku_papertrail_plan  = "volmar"
 
-  django_default_from_email          = "admin@api.dandiarchive.org"
-  django_cors_origin_whitelist       = [
+  django_default_from_email = "admin@api.dandiarchive.org"
+  django_cors_origin_whitelist = [
     "https://gui.dandiarchive.org",
     "https://gui-beta-dandiarchive-org.netlify.app",
-    "https://codepen.io",
-    "https://cdpn.io",
-    "https://bioimagesuiteweb.github.io"
   ]
   django_cors_origin_regex_whitelist = ["^https:\\/\\/[0-9a-z\\-]+--gui-dandiarchive-org\\.netlify\\.app$"]
 


### PR DESCRIPTION
There is now a signal handler that allows read only CORS requests from
any origin, so these explicit exceptions are no longer required.

Fixes #91 