### PR TITLE
Do not set DJANGO_DANDI_SCHEMA_VERSION

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -28,7 +28,6 @@ module "api" {
     # DJANGO_DANDI_DANDISETS_BUCKET_NAME = aws_s3_bucket.sponsored_bucket.id
     DJANGO_DANDI_DANDISETS_BUCKET_NAME   = aws_s3_bucket.sponsored_bucket.id
     DJANGO_DANDI_DANDISETS_BUCKET_PREFIX = ""
-    DJANGO_DANDI_SCHEMA_VERSION          = "0.5.1"
     DJANGO_DANDI_DOI_API_URL             = "https://api.datacite.org/dois"
     DJANGO_DANDI_DOI_API_USER            = "dartlib.dandi"
     DJANGO_DANDI_DOI_API_PREFIX          = "10.48324"

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -24,7 +24,6 @@ module "api_staging" {
     DJANGO_CONFIGURATION                 = "HerokuStagingConfiguration"
     DJANGO_DANDI_DANDISETS_BUCKET_NAME   = aws_s3_bucket.api_staging_dandisets_bucket.id
     DJANGO_DANDI_DANDISETS_BUCKET_PREFIX = ""
-    DJANGO_DANDI_SCHEMA_VERSION          = "0.5.1"
     DJANGO_DANDI_DOI_API_URL             = "https://api.test.datacite.org/dois"
     DJANGO_DANDI_DOI_API_USER            = "dartlib.dandi"
     DJANGO_DANDI_DOI_API_PREFIX          = "10.80507"


### PR DESCRIPTION
This is now set in the dandi-api settings.py, so we do not need to set
it in Terraform.

See https://github.com/dandi/dandi-api/pull/494