### PR TITLE
Add an SPF record for email handling

### DIFF
--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -44,3 +44,11 @@ resource "aws_route53_record" "email" {
     "20 mx2.improvmx.com.",
   ]
 }
+
+resource "aws_route53_record" "email-spf" {
+  zone_id = aws_route53_zone.dandi.zone_id
+  name    = "" # apex
+  type    = "TXT"
+  ttl     = "300"
+  records = ["v=spf1 include:spf.improvmx.com ~all"]
+}


### PR DESCRIPTION
This record is recommended by the ImprovMX setup procedures, which we are using for managing dandiarchive.org email addresses.