### PR TITLE
Add checksum-worker formations

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -41,6 +41,13 @@ module "api" {
   }
 }
 
+resource "heroku_formation" "api_checksum_worker" {
+  app      = module.api.heroku_app_id
+  type     = "checksum-worker"
+  size     = "standard-1x"
+  quantity = 1
+}
+
 data "aws_iam_user" "api" {
   user_name = module.api.iam_user_id
 }

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -38,6 +38,13 @@ module "api_staging" {
   }
 }
 
+resource "heroku_formation" "api_staging_checksum_worker" {
+  app      = module.api_staging.heroku_app_id
+  type     = "checksum-worker"
+  size     = "hobby"
+  quantity = 1
+}
+
 data "aws_iam_user" "api_staging" {
   user_name = module.api_staging.heroku_iam_user_id
 }


### PR DESCRIPTION
The Girder 4 terraform module wires up `web` and `worker` dynos by
default. We now have a `checksum-worker` dyno which should also be
managed by Terraform, so we need to explicitly declare it next to our
`api` and `api-staging` declarations.