### PR TITLE
Add missing env var to terraform config

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -28,7 +28,7 @@ module "api" {
   django_cors_origin_regex_whitelist = ["^https:\\/\\/[0-9a-z\\-]+--gui-dandiarchive-org\\.netlify\\.app$"]
 
   additional_django_vars = {
-    # DJANGO_DANDI_DANDISETS_BUCKET_NAME = aws_s3_bucket.sponsored_bucket.id
+    DJANGO_CONFIGURATION                 = "HerokuProductionConfiguration"
     DJANGO_DANDI_DANDISETS_BUCKET_NAME   = aws_s3_bucket.sponsored_bucket.id
     DJANGO_DANDI_DANDISETS_BUCKET_PREFIX = ""
     DJANGO_DANDI_DOI_API_URL             = "https://api.datacite.org/dois"


### PR DESCRIPTION
I noticed the `DJANGO_CONFIGURATION` environment variable is set for the staging server https://github.com/dandi/dandi-infrastructure/blob/master/terraform/staging_pipeline.tf#L27 but not for production (it is set in heroku though, presumably someone set it manually there).