### PR TITLE
Fix user argument for dandiset bucket module

### DIFF
--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -73,14 +73,14 @@ resource "aws_s3_bucket" "log_bucket" {
 
 resource "aws_iam_user_policy" "dandiset_bucket_owner" {
   name = "${var.bucket_name}-ownership-policy"
-  user = var.heroku_user_arn
+  user = var.heroku_user.user_name
 
   policy = jsonencode({
     Version = "2008-10-17"
     Statement = [
       {
         Principal = {
-          "AWS" = [var.heroku_user_arn]
+          "AWS" = [var.heroku_user.arn]
         }
         Action = [
           "s3:*",

--- a/terraform/modules/dandiset_bucket/variables.tf
+++ b/terraform/modules/dandiset_bucket/variables.tf
@@ -13,9 +13,8 @@ variable "versioning" {
   description = "Whether or not versioning should be enabled on the bucket."
 }
 
-variable "heroku_user_arn" {
-  type        = string
-  description = "The name of the Heroku API user who will have write access to the bucket."
+variable "heroku_user" {
+  description = "The Heroku API IAM user who will have write access to the bucket."
 }
 
 variable "log_bucket_name" {

--- a/terraform/sponsored_bucket.tf
+++ b/terraform/sponsored_bucket.tf
@@ -164,7 +164,7 @@ module "sponsored_embargo_bucket" {
   source          = "./modules/dandiset_bucket"
   bucket_name     = "dandiarchive-embargo"
   versioning      = false
-  heroku_user_arn = data.aws_iam_user.api.arn
+  heroku_user     = data.aws_iam_user.api
   log_bucket_name = "dandiarchive-embargo-logs"
   providers = {
     aws = aws.sponsored

--- a/terraform/staging_bucket.tf
+++ b/terraform/staging_bucket.tf
@@ -160,7 +160,7 @@ module "staging_embargo_bucket" {
   source          = "./modules/dandiset_bucket"
   bucket_name     = "dandi-api-staging-embargo-dandisets"
   versioning      = false
-  heroku_user_arn = data.aws_iam_user.api_staging.arn
+  heroku_user     = data.aws_iam_user.api_staging
   log_bucket_name = "dandi-api-staging-embargo-dandisets-logs"
   providers = {
     aws = aws


### PR DESCRIPTION
I made a mistake in #105 and passed an ARN where the module expected a username.