### PR TITLE
Allow Get, List, and Delete without ACL

### DIFF
--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -82,6 +82,18 @@ resource "aws_iam_user_policy" "dandiset_bucket_owner" {
     Statement = [
       {
         Action = [
+          "s3:Get*",
+          "s3:List*",
+          "s3:Delete*",
+        ]
+        Effect = "Allow"
+        Resource = [
+          "${aws_s3_bucket.dandiset_bucket.arn}",
+          "${aws_s3_bucket.dandiset_bucket.arn}/*",
+        ]
+      },
+      {
+        Action = [
           "s3:*",
         ]
         Effect = "Allow"


### PR DESCRIPTION
The header setting X-Amz-ACL=bucket-owner-full-control is only
meaningful on "Put" operations. We were requiring it for all operations,
which meant that read operations were not allowed, as they did not
include it.

Fixes https://github.com/dandi/dandi-archive/issues/809