### PR TITLE
Update CORS whitelists

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -21,10 +21,7 @@ module "api" {
   heroku_worker_dyno_quantity = 1
 
   django_default_from_email = "admin@api.dandiarchive.org"
-  django_cors_origin_whitelist = [
-    "https://gui.dandiarchive.org",
-    "https://gui-beta-dandiarchive-org.netlify.app",
-  ]
+  django_cors_origin_whitelist = ["https://gui.dandiarchive.org"]
   django_cors_origin_regex_whitelist = ["^https:\\/\\/[0-9a-z\\-]+--gui-dandiarchive-org\\.netlify\\.app$"]
 
   additional_django_vars = {

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -21,7 +21,7 @@ module "api_staging" {
 
   django_default_from_email          = "admin@api-staging.dandiarchive.org"
   django_cors_origin_whitelist       = ["https://gui-staging.dandiarchive.org"]
-  django_cors_origin_regex_whitelist = ["^https:\\/\\/[0-9a-z\\-]+--gui-dandiarchive-org\\.netlify\\.app$"]
+  django_cors_origin_regex_whitelist = ["^https:\\/\\/[0-9a-z\\-]+--gui-staging-dandiarchive-org\\.netlify\\.app$"]
 
   additional_django_vars = {
     DJANGO_CONFIGURATION                         = "HerokuStagingConfiguration"


### PR DESCRIPTION
We recently moved Netlify deploy previews to the staging Netlify "app", so they now live at `https://deploy-preview-*--gui-staging-dandiarchive-org.netlify.app/`  instead of `https://deploy-preview-*--gui-dandiarchive-org.netlify.app/`. This PR updates the CORS whitelist for the staging server with this new URL format.

I also removed the `https://gui-beta-dandiarchive-org.netlify.app` URL from the production server CORS whitelist. It doesn't point to anything, and I suspect it's just an outdated URL that was never removed from the terraform config - @waxlamp @dchiquito @AlmightyYakob does anyone remember what this URL was used for, and can confirm that it's okay to remove?