### PR TITLE
Add manifest worker

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -20,8 +20,8 @@ module "api" {
   heroku_web_dyno_quantity    = 1
   heroku_worker_dyno_quantity = 1
 
-  django_default_from_email = "admin@api.dandiarchive.org"
-  django_cors_origin_whitelist = ["https://gui.dandiarchive.org"]
+  django_default_from_email          = "admin@api.dandiarchive.org"
+  django_cors_origin_whitelist       = ["https://gui.dandiarchive.org"]
   django_cors_origin_regex_whitelist = ["^https:\\/\\/[0-9a-z\\-]+--gui-dandiarchive-org\\.netlify\\.app$"]
 
   additional_django_vars = {
@@ -49,6 +49,13 @@ resource "heroku_formation" "api_checksum_worker" {
   app      = module.api.heroku_app_id
   type     = "checksum-worker"
   size     = "standard-1x"
+  quantity = 1
+}
+
+resource "heroku_formation" "api_checksum_worker" {
+  app      = module.api.heroku_app_id
+  type     = "manifest-worker"
+  size     = "standard-2x"
   quantity = 1
 }
 

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -51,6 +51,13 @@ resource "heroku_formation" "api_staging_checksum_worker" {
   quantity = 1
 }
 
+resource "heroku_formation" "api_staging_checksum_worker" {
+  app      = module.api_staging.heroku_app_id
+  type     = "manifest-worker"
+  size     = "hobby"
+  quantity = 1
+}
+
 data "aws_iam_user" "api_staging" {
   user_name = module.api_staging.heroku_iam_user_id
 }


### PR DESCRIPTION
Add the dyno specifications for the staging and production manifest queue workers.

This should only be merged after https://github.com/dandi/dandi-archive/pull/977 is released, since the worker needs to be defined in `Procfil` before terraform can interact with it.