### PR TITLE
Add bucket policy to dandiset_bucket module

### DIFF
--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -110,3 +110,47 @@ resource "aws_iam_user_policy" "dandiset_bucket_owner" {
     ]
   })
 }
+
+resource "aws_s3_bucket_policy" "dandiset_bucket_policy" {
+  provider = aws
+
+  bucket = aws_s3_bucket.dandiset_bucket.id
+  policy = jsonencode({
+    Version = "2008-10-17"
+    Statement = [
+      {
+        Principal = {
+          AWS = var.heroku_user.arn
+        }
+        Action = [
+          "s3:Get*",
+          "s3:List*",
+          "s3:Delete*",
+        ]
+        Effect = "Allow"
+        Resource = [
+          "${aws_s3_bucket.dandiset_bucket.arn}",
+          "${aws_s3_bucket.dandiset_bucket.arn}/*",
+        ]
+      },
+      {
+        Principal = {
+          AWS = var.heroku_user.arn
+        }
+        Action = [
+          "s3:*",
+        ]
+        Effect = "Allow"
+        Resource = [
+          "${aws_s3_bucket.dandiset_bucket.arn}",
+          "${aws_s3_bucket.dandiset_bucket.arn}/*",
+        ]
+        "Condition" : {
+          "StringEquals" : {
+            "s3:x-amz-acl" : "bucket-owner-full-control"
+          }
+        }
+      },
+    ]
+  })
+}


### PR DESCRIPTION
Currently, the dandiset_bucket module is only used for embargo buckets.
The production embargo bucket isn't working because the Heroku IAM user
is in a different account than the embargo bucket.

Add a new bucket policy to the staging and production buckets that
explicitly allow the IAM user to do anything to the bucket. Cross
account access requires that both the IAM user and the bucket have a
policy allowing access.

To resolve the issue and verify that this is the correct solution, I manually put this policy onto the production embargo bucket:
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "Statement1",
            "Effect": "Allow",
            "Principal": {
                "AWS": "arn:aws:iam::278212569472:user/dandi-api-heroku"
            },
            "Action": "s3:*",
            "Resource": [
                "arn:aws:s3:::dandiarchive-embargo/*",
                "arn:aws:s3:::dandiarchive-embargo"
            ]
        }
    ]
}
```
This PR adds that configuration to terraform.

Fixes https://github.com/dandi/dandi-archive/issues/1035