### PR TITLE
allow HEAD requests from different origins.

### DIFF
--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -34,6 +34,7 @@ resource "aws_s3_bucket_cors_configuration" "dandiset_bucket" {
       "PUT",
       "POST",
       "GET",
+      "HEAD",
       "DELETE",
     ]
     allowed_headers = [


### PR DESCRIPTION
we are trying to see if we can load nwb files remotely and this particular tool first makes a head request: https://github.com/usnistgov/h5wasm/issues/12

this PR allows cross-origin head requests.