### PR TITLE
Change `heroku_web_dyno_size` to standard-2x

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -11,7 +11,7 @@ module "api" {
   route53_zone_id  = aws_route53_zone.dandi.zone_id
   subdomain_name   = "api"
 
-  heroku_web_dyno_size    = "standard-1x"
+  heroku_web_dyno_size    = "standard-2x"
   heroku_worker_dyno_size = "standard-2x"
   heroku_postgresql_plan  = "standard-0"
   heroku_cloudamqp_plan   = "tiger"


### PR DESCRIPTION
The Heroku web dyno is currently set to 2X in Heroku, but 1X in the Terraform config. The dyno was scaled up to 2X by hand a while back, but that change was never encoded in Terraform. 