### PR TITLE
Update CloudAMQP plan in Terraform

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -14,7 +14,7 @@ module "api" {
   heroku_web_dyno_size    = "standard-2x"
   heroku_worker_dyno_size = "standard-2x"
   heroku_postgresql_plan  = "standard-0"
-  heroku_cloudamqp_plan   = "tiger"
+  heroku_cloudamqp_plan   = "squirrel-1"
   heroku_papertrail_plan  = "volmar"
 
   heroku_web_dyno_quantity    = 1


### PR DESCRIPTION
We've switched to Sassy-Squirel-1 tier for CloudAMQP, but the Terraform code wasn't updated accordingly.