### PR TITLE
Update Terraform values to be consistent with Heroku web console

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -49,7 +49,7 @@ module "api" {
 resource "heroku_formation" "api_checksum_worker" {
   app      = module.api.heroku_app_id
   type     = "checksum-worker"
-  size     = "standard-1x"
+  size     = "standard-2x"
   quantity = 1
 }
 

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -10,9 +10,9 @@ module "api_staging" {
   route53_zone_id  = aws_route53_zone.dandi.zone_id
   subdomain_name   = "api-staging"
 
-  heroku_web_dyno_size    = "hobby"
-  heroku_worker_dyno_size = "hobby"
-  heroku_postgresql_plan  = "hobby-basic"
+  heroku_web_dyno_size    = "basic"
+  heroku_worker_dyno_size = "basic"
+  heroku_postgresql_plan  = "basic"
   heroku_cloudamqp_plan   = "tiger"
   heroku_papertrail_plan  = "fixa"
 
@@ -48,7 +48,7 @@ module "api_staging" {
 resource "heroku_formation" "api_staging_checksum_worker" {
   app      = module.api_staging.heroku_app_id
   type     = "checksum-worker"
-  size     = "hobby"
+  size     = "basic"
   quantity = 1
 }
 


### PR DESCRIPTION
Our Heroku configuration has drifted away from our Terraform state. This PR updates our Terraform code to represent the current state of Heroku; in other words, this should be a no-op when applied and will only affect the state file on TF Cloud.