### PR TITLE
Bring terraform state up to date

### DIFF
--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -36,6 +36,14 @@ resource "aws_s3_bucket" "dandiset_bucket" {
   lifecycle {
     prevent_destroy = true
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 resource "aws_s3_bucket_ownership_controls" "dandiset_bucket" {
@@ -67,6 +75,14 @@ resource "aws_s3_bucket" "log_bucket" {
 
   lifecycle {
     prevent_destroy = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
   }
 }
 

--- a/terraform/sponsored_bucket.tf
+++ b/terraform/sponsored_bucket.tf
@@ -36,6 +36,14 @@ resource "aws_s3_bucket" "sponsored_bucket" {
   lifecycle {
     prevent_destroy = true
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 resource "aws_s3_bucket_ownership_controls" "sponsored_bucket" {
@@ -69,6 +77,14 @@ resource "aws_s3_bucket" "sponsored_bucket_logs" {
 
   lifecycle {
     prevent_destroy = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
   }
 }
 

--- a/terraform/staging_bucket.tf
+++ b/terraform/staging_bucket.tf
@@ -35,6 +35,14 @@ resource "aws_s3_bucket" "api_staging_dandisets_bucket" {
   lifecycle {
     prevent_destroy = true
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 resource "aws_s3_bucket_ownership_controls" "api_staging_dandisets_bucket" {
@@ -67,6 +75,13 @@ resource "aws_s3_bucket" "api_staging_dandisets_bucket_logs" {
 
   lifecycle {
     prevent_destroy = true
+  }
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
   }
 }
 

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -13,7 +13,7 @@ module "api_staging" {
   heroku_web_dyno_size    = "basic"
   heroku_worker_dyno_size = "basic"
   heroku_postgresql_plan  = "basic"
-  heroku_cloudamqp_plan   = "tiger"
+  heroku_cloudamqp_plan   = "squirrel-1"
   heroku_papertrail_plan  = "fixa"
 
   heroku_web_dyno_quantity    = 1


### PR DESCRIPTION
This brings our state back to parity with production:
- Codifies the encryption status of the buckets
- Upgrades the cloudamqp plan (a manual rm/import was done locally)