### PR TITLE
Remove policy name variable

### DIFF
--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -4,10 +4,6 @@ data "aws_caller_identity" "sponsored_account" {
   provider = aws
 }
 
-locals {
-  ownership_policy_name = var.ownership_policy_name == "" ? "${var.bucket_name}-ownership-policy" : var.ownership_policy_name
-}
-
 resource "aws_s3_bucket" "dandiset_bucket" {
 
   bucket = var.bucket_name
@@ -98,7 +94,7 @@ resource "aws_iam_user_policy" "dandiset_bucket_owner" {
   // The Heroku IAM user will always be in the project account
   provider = aws.project
 
-  name = local.ownership_policy_name
+  name = "${var.bucket_name}-ownership-policy"
   user = var.heroku_user.user_name
 
   policy = data.aws_iam_policy_document.dandiset_bucket_owner.json

--- a/terraform/modules/dandiset_bucket/variables.tf
+++ b/terraform/modules/dandiset_bucket/variables.tf
@@ -26,13 +26,6 @@ variable "allow_cross_account_heroku_put_object" {
   default = false
 }
 
-# TODO: remove after migration
-variable "ownership_policy_name" {
-  type        = string
-  description = "The name of the policy for the IAM user role."
-  default     = ""
-}
-
 variable "versioning" {
   type        = bool
   description = "Whether or not versioning should be enabled on the bucket."

--- a/terraform/modules/dandiset_bucket/variables.tf
+++ b/terraform/modules/dandiset_bucket/variables.tf
@@ -1,8 +1,3 @@
-# variable "aws_provider" {
-#   # type        = string //??
-#   description = "The AWS provider."
-# }
-
 variable "public" {
   type        = bool
   description = "Whether or not the contents of the bucket should be public."

--- a/terraform/sponsored_bucket.tf
+++ b/terraform/sponsored_bucket.tf
@@ -1,7 +1,6 @@
 module "sponsored_dandiset_bucket" {
   source                                = "./modules/dandiset_bucket"
   bucket_name                           = "dandiarchive"
-  ownership_policy_name                 = "dandi-api-sponsored-bucket"
   public                                = true
   versioning                            = true
   allow_cross_account_heroku_put_object = true


### PR DESCRIPTION
This was just put in place to make the diffs a bit easier to read, but now we can remove it which will trigger a delete/recreate of the policy.