### PR TITLE
Add action to auto-add new issues to project board

### DIFF
--- a/.github/workflows/auto-add-issues.yml
+++ b/.github/workflows/auto-add-issues.yml
@@ -1,0 +1,17 @@
+name: Add issues to beta project
+
+on:
+  issues:
+    types:
+      - opened
+      - transferred
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/dandi/projects/16
+          github-token: ${{ secrets.AUTO_ADD_ISSUES }}


### PR DESCRIPTION
This should cause new issues filed here to show up in our project board.

Note that this is an identical copy of the same workflow file in dandi-archive. After brief reading about using an org-level .github repository, I'm not sure that's the right way to share this workflow between repos (unless we do that and then use "caller" workflows in each repository--that would be better than this straight copying, I guess).

I'd like to merge this in so we can have the auto-add functionality, then revisit later to refactor the workflow out into a common space, if possible. If there's a simple way to accomplish that right away, let me know and we can maybe do that instead.

TODO:
- [ ] After this is merged, go through and manually add the existing issues to the project board (@waxlamp)