### PR TITLE
Restore old CloudAMQP tier for staging

### DIFF
--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -13,7 +13,7 @@ module "api_staging" {
   heroku_web_dyno_size    = "basic"
   heroku_worker_dyno_size = "basic"
   heroku_postgresql_plan  = "basic"
-  heroku_cloudamqp_plan   = "squirrel-1"
+  heroku_cloudamqp_plan   = "tiger"
   heroku_papertrail_plan  = "fixa"
 
   heroku_web_dyno_quantity    = 1


### PR DESCRIPTION
Our monthly billing cycle has rolled over for our staging CloudAMQP plan, so we can restore it back to the cheaper tier now.