### PR TITLE
Move log bucket resources to seperate file

### DIFF
--- a/terraform/modules/dandiset_bucket/log_bucket.tf
+++ b/terraform/modules/dandiset_bucket/log_bucket.tf
@@ -1,0 +1,68 @@
+data "aws_canonical_user_id" "log_bucket_owner_account" {}
+
+resource "aws_s3_bucket" "log_bucket" {
+  bucket = var.log_bucket_name
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+data "aws_iam_policy_document" "dandiset_log_bucket_policy" {
+  statement {
+    resources = [
+      "${aws_s3_bucket.log_bucket.arn}",
+      "${aws_s3_bucket.log_bucket.arn}/*",
+    ]
+
+    actions = [
+      # Needed for the app to process logs for collecting download analytics
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.heroku_user.arn]
+    }
+  }
+
+  statement {
+    sid       = "S3ServerAccessLogsPolicy"
+    effect    = "Allow"
+    resources = ["${aws_s3_bucket.log_bucket.arn}/*"]
+    actions   = ["s3:PutObject"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = [aws_s3_bucket.dandiset_bucket.arn]
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = ["logging.s3.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "dandiset_log_bucket_policy" {
+  provider = aws
+
+  bucket = aws_s3_bucket.log_bucket.id
+  policy = data.aws_iam_policy_document.dandiset_log_bucket_policy.json
+}

--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -84,20 +84,6 @@ data "aws_iam_policy_document" "dandiset_bucket_owner" {
     ]
   }
 
-  // TODO: gate behind a "cross account" flag, since this is technically only
-  // needed for sponsored log bucket.
-  statement {
-    resources = [
-      "${aws_s3_bucket.log_bucket.arn}",
-      "${aws_s3_bucket.log_bucket.arn}/*",
-    ]
-
-    actions = [
-      "s3:GetObject",
-      "s3:ListBucket",
-    ]
-  }
-
   dynamic "statement" {
     for_each = var.allow_heroku_put_object ? [1] : []
     content {
@@ -126,7 +112,6 @@ data "aws_iam_policy_document" "dandiset_bucket_owner" {
     }
   }
 }
-
 
 resource "aws_s3_bucket_policy" "dandiset_bucket_policy" {
   provider = aws


### PR DESCRIPTION
This is a minor refactor of the `dandiset_bucket` module that moves all resources related to the logging bucket to a separate file to make it easier to parse what's going on without confusing the two buckets.

Note this does split an IAM User policy into two separate policies, so merging and applying this will mutate the infrastructure.