### PR TITLE
Update deprecated `aws_s3_bucket` attributes

### DIFF
--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -10,10 +10,6 @@ resource "aws_s3_bucket" "dandiset_bucket" {
   // Public access is granted via a bucket policy, not a canned ACL
   acl = "private"
 
-  logging {
-    target_bucket = aws_s3_bucket.log_bucket.id
-  }
-
   versioning {
     enabled = var.versioning
   }
@@ -52,6 +48,13 @@ resource "aws_s3_bucket_cors_configuration" "dandiset_bucket" {
     ]
     max_age_seconds = 3000
   }
+}
+
+resource "aws_s3_bucket_logging" "dandiset_bucket" {
+  bucket = aws_s3_bucket.dandiset_bucket.id
+
+  target_bucket = aws_s3_bucket.log_bucket.id
+  target_prefix = ""
 }
 
 resource "aws_s3_bucket_ownership_controls" "dandiset_bucket" {

--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -10,25 +10,6 @@ resource "aws_s3_bucket" "dandiset_bucket" {
   // Public access is granted via a bucket policy, not a canned ACL
   acl = "private"
 
-  cors_rule {
-    allowed_origins = [
-      "*",
-    ]
-    allowed_methods = [
-      "PUT",
-      "POST",
-      "GET",
-      "DELETE",
-    ]
-    allowed_headers = [
-      "*"
-    ]
-    expose_headers = [
-      "ETag",
-    ]
-    max_age_seconds = 3000
-  }
-
   logging {
     target_bucket = aws_s3_bucket.log_bucket.id
   }
@@ -47,6 +28,29 @@ resource "aws_s3_bucket" "dandiset_bucket" {
         sse_algorithm = "AES256"
       }
     }
+  }
+}
+
+resource "aws_s3_bucket_cors_configuration" "dandiset_bucket" {
+  bucket = aws_s3_bucket.dandiset_bucket.id
+
+  cors_rule {
+    allowed_origins = [
+      "*",
+    ]
+    allowed_methods = [
+      "PUT",
+      "POST",
+      "GET",
+      "DELETE",
+    ]
+    allowed_headers = [
+      "*"
+    ]
+    expose_headers = [
+      "ETag",
+    ]
+    max_age_seconds = 3000
   }
 }
 

--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -10,10 +10,6 @@ resource "aws_s3_bucket" "dandiset_bucket" {
   // Public access is granted via a bucket policy, not a canned ACL
   acl = "private"
 
-  versioning {
-    enabled = var.versioning
-  }
-
   lifecycle {
     prevent_destroy = true
   }
@@ -55,6 +51,16 @@ resource "aws_s3_bucket_logging" "dandiset_bucket" {
 
   target_bucket = aws_s3_bucket.log_bucket.id
   target_prefix = ""
+}
+
+resource "aws_s3_bucket_versioning" "dandiset_bucket" {
+  for_each = var.versioning ? [1] : []
+
+  bucket = aws_s3_bucket.dandiset_bucket.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
 }
 
 resource "aws_s3_bucket_ownership_controls" "dandiset_bucket" {


### PR DESCRIPTION
Many of the attributes we're using on the `aws_s3_bucket` resource are deprecated, see https://registry.terraform.io/providers/-/aws/latest/docs/resources/s3_bucket.