### PR TITLE
Upgrade `girder/girder4/heroku` module to latest version

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -4,7 +4,7 @@ data "heroku_team" "dandi" {
 
 module "api" {
   source  = "girder/girder4/heroku"
-  version = "0.12.0"
+  version = "0.13.0"
 
   project_slug     = "dandi-api"
   heroku_team_name = data.heroku_team.dandi.name

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -3,7 +3,7 @@
 
 module "api_staging" {
   source  = "girder/girder4/heroku"
-  version = "0.12.0"
+  version = "0.13.0"
 
   project_slug     = "dandi-api-staging"
   heroku_team_name = data.heroku_team.dandi.name


### PR DESCRIPTION
Requires #160 to be merged first. 