### PR TITLE
Disable Rust buildpack and dyno-metadata feature

### DIFF
--- a/terraform/webdav.tf
+++ b/terraform/webdav.tf
@@ -8,7 +8,10 @@ resource "heroku_app" "webdav" {
   }
 
   buildpacks = [
-    "https://buildpack-registry.s3.amazonaws.com/buildpacks/emk/rust.tgz"
+    # The Rust application is compiled and pushed to Heroku via a GitHub Action, so
+    # we don't need to specify a specific buildpack here. So, we just fall back to
+    # the Heroku CLI buildpack as a default.
+    "heroku-community/cli"
   ]
 }
 
@@ -17,12 +20,6 @@ resource "heroku_formation" "webdav_heroku_web" {
   type     = "web"
   size     = "basic"
   quantity = 1
-}
-
-# Enable this feature so that the Rust application can access the git commit hash.
-resource "heroku_app_feature" "webdav_runtime_dyno_metadata" {
-  app_id = heroku_app.webdav.id
-  name   = "runtime-dyno-metadata"
 }
 
 resource "heroku_domain" "webdav" {


### PR DESCRIPTION
Neither of these are needed anymore now that we are deploying by pushing directly to Heroku. See https://github.com/dandi/dandidav/pull/105.

I picked the `heroku-community/cli` because a Heroku app requires at least 1 buildpack to deploy successfully, and it was the closest thing to a "no-op" buildpack officially maintained by Heroku.