### PR TITLE
Use a trailing dot for AWS ACM validation record

### DIFF
--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -7,7 +7,7 @@ resource "aws_route53_record" "acm_validation" {
   name    = "_cbe41dfe1888c2bb5c157cacc35e1722"
   type    = "CNAME"
   ttl     = "300"
-  records = ["_46df7ee9a9c17698aedbb737f220c63a.mzlfeqexyx.acm-validations.aws"]
+  records = ["_46df7ee9a9c17698aedbb737f220c63a.mzlfeqexyx.acm-validations.aws."]
 }
 
 resource "aws_route53_record" "gui" {


### PR DESCRIPTION
This corrects a spurious plan element that seems to show up in every plan, in which the domain for the AWS ACM validation record loses a trailing dot.

The Terraform code indeed does not include the trailing dot, but it seems as though at runtime, the deployed resource somehow gains it, leaving the deployed state inconsistent with the code. I don't know what causes that, but this "fixes" the problem by bringing the code into line with what the deployed resource seems to be.

For an example of a TF plan that includes the spurious change, see https://app.terraform.io/app/dandi/workspaces/dandi-prod/runs/run-VFdyCNW18mBqo6ju.

If there's a better way to solve this, let's close this PR and pursue that solution instead.

Unrelated to the fix, but the plan also includes a change to the dandidav buildpack infrastructure. I'm not sure why that's happening, as this PR was intended to be something of a no-op w/r/t the TF plan.