### PR TITLE
Use full URL for webdav buildpack

### DIFF
--- a/terraform/webdav.tf
+++ b/terraform/webdav.tf
@@ -11,7 +11,7 @@ resource "heroku_app" "webdav" {
     # The Rust application is compiled and pushed to Heroku via a GitHub Action, so
     # we don't need to specify a specific buildpack here. So, we just fall back to
     # the Heroku CLI buildpack as a default.
-    "heroku-community/cli"
+    "https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku-community/cli.tgz"
   ]
 }
 


### PR DESCRIPTION
Using just `heroku-community/cli` results in subsequent Terraform plans wanting to change it to the full URL.