### PR TITLE
Remove trailing dot for ACM CNAME entry

### DIFF
--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -7,7 +7,7 @@ resource "aws_route53_record" "acm_validation" {
   name    = "_cbe41dfe1888c2bb5c157cacc35e1722"
   type    = "CNAME"
   ttl     = "300"
-  records = ["_46df7ee9a9c17698aedbb737f220c63a.mzlfeqexyx.acm-validations.aws."]
+  records = ["_46df7ee9a9c17698aedbb737f220c63a.mzlfeqexyx.acm-validations.aws"]
 }
 
 resource "aws_route53_record" "gui" {


### PR DESCRIPTION
Following on from the drama in #176, this PR attempts to go back to not using the trailing dot for that Route53 CNAME entry so it is in line with the other entries.

We believe this cycle of adding the dot and then removing it will eliminate the hiccup, but we need to observe what happens after this PR is merge in order to make sure.