### PR TITLE
Revert "Remove trailing dot for ACM CNAME entry"

### DIFF
--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -7,7 +7,7 @@ resource "aws_route53_record" "acm_validation" {
   name    = "_cbe41dfe1888c2bb5c157cacc35e1722"
   type    = "CNAME"
   ttl     = "300"
-  records = ["_46df7ee9a9c17698aedbb737f220c63a.mzlfeqexyx.acm-validations.aws"]
+  records = ["_46df7ee9a9c17698aedbb737f220c63a.mzlfeqexyx.acm-validations.aws."]
 }
 
 resource "aws_route53_record" "gui" {


### PR DESCRIPTION
Reverts dandi/dandi-infrastructure#178

#178 was an experiment in seeing whether we could have a trailing-dot-free record in Terraform. It did not work, probability due to something we are missing, but inlcuding the trailing dot doesn't harm anything, and in fact reflects the value currently held by Route53.