### PR TITLE
Give Heroku user `s3:PutObjectTagging` permission

### DIFF
--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -116,7 +116,7 @@ data "aws_iam_policy_document" "dandiset_bucket_owner" {
         "${aws_s3_bucket.dandiset_bucket.arn}/*",
       ]
 
-      actions = ["s3:PutObject"]
+      actions = ["s3:PutObject", "s3:PutObjectTagging"]
     }
   }
 


### PR DESCRIPTION
This permission is needed in order to allow the Heroku application to set the `embargoed` tag on embargoed blobs.