### PR TITLE
Specify developer email list as env var

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -42,6 +42,7 @@ module "api" {
     DJANGO_DANDI_WEB_APP_URL                       = "https://dandiarchive.org"
     DJANGO_DANDI_API_URL                           = "https://api.dandiarchive.org"
     DJANGO_DANDI_JUPYTERHUB_URL                    = "https://hub.dandiarchive.org/"
+    DJANGO_DANDI_DEV_EMAIL                         = var.dev_email
   }
   additional_sensitive_django_vars = {
     DJANGO_DANDI_DOI_API_PASSWORD = var.doi_api_password

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -41,6 +41,7 @@ module "api_staging" {
     DJANGO_DANDI_WEB_APP_URL                       = "https://gui-staging.dandiarchive.org"
     DJANGO_DANDI_API_URL                           = "https://api-staging.dandiarchive.org"
     DJANGO_DANDI_JUPYTERHUB_URL                    = "https://hub.dandiarchive.org/"
+    DJANGO_DANDI_DEV_EMAIL                         = var.dev_email
   }
   additional_sensitive_django_vars = {
     DJANGO_DANDI_DOI_API_PASSWORD = var.test_doi_api_password

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,3 +7,8 @@ variable "test_doi_api_password" {
   type        = string
   description = "The password for the Datacite Test API, used to mint new DOIs on staging during publish."
 }
+
+variable "dev_email" {
+  type        = string
+  description = "The core developer email list."
+}


### PR DESCRIPTION
This PR adds a `dev_email` variable that will be passed to django via the `DJANGO_DANDI_DEV_EMAIL` env var. The value for this terraform setting has already been supplied in terraform cloud.