### PR TITLE
Allow PutObjectTagging for both production and staging buckets

### DIFF
--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -108,7 +108,7 @@ data "aws_iam_policy_document" "dandiset_bucket_owner" {
   }
 
   dynamic "statement" {
-    for_each = var.allow_heroku_put_object ? [1] : []
+    for_each = (var.allow_cross_account_heroku_put_object || var.allow_heroku_put_object) ? [1] : []
     content {
 
       resources = [


### PR DESCRIPTION
Follow up to https://github.com/dandi/dandi-infrastructure/pull/180. That PR applied this change for only the staging bucket. This PR additionally applies this change to the production bucket as well.