### PR TITLE
Add `s3:PutObjectTagging` permission to sponsored bucket

### DIFF
--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -266,6 +266,23 @@ data "aws_iam_policy_document" "dandiset_bucket_policy" {
   }
 
   dynamic "statement" {
+    for_each = var.allow_cross_account_heroku_put_object ? [1] : []
+    content {
+      resources = [
+        "${aws_s3_bucket.dandiset_bucket.arn}",
+        "${aws_s3_bucket.dandiset_bucket.arn}/*",
+      ]
+
+      actions = ["s3:PutObjectTagging"]
+
+      principals {
+        type        = "AWS"
+        identifiers = [var.heroku_user.arn]
+      }
+    }
+  }
+
+  dynamic "statement" {
     for_each = var.trailing_delete ? [1] : []
 
     content {


### PR DESCRIPTION
This gives the production heroku user permission for the `PutObjectTagging` action, from the bucket policy itself. This actually solves the issue that #182 was attempting to solve. That change didn't work because permissions to the production bucket must be added on the bucket policy itself (because the bucket and user reside in two different accounts), and we were only adding that permission to the user itself, not the bucket.