### PR TITLE
Add identity provider for terraform cloud

### DIFF
--- a/terraform/aws_oidc.tf
+++ b/terraform/aws_oidc.tf
@@ -1,0 +1,43 @@
+data "tls_certificate" "tfc_certificate" {
+  url = "https://app.terraform.io"
+}
+
+resource "aws_iam_openid_connect_provider" "tfc_provider" {
+  url             = data.tls_certificate.tfc_certificate.url
+  client_id_list  = ["aws.workload.identity"]
+  thumbprint_list = [data.tls_certificate.tfc_certificate.certificates[0].sha1_fingerprint]
+}
+
+resource "aws_iam_role" "tfc_role" {
+  name = "terraform-cloud-role"
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "${aws_iam_openid_connect_provider.tfc_provider.arn}"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "app.terraform.io:aud" : "${one(aws_iam_openid_connect_provider.tfc_provider.client_id_list)}"
+          },
+          "StringLike" : {
+            "app.terraform.io:sub" : "organization:dandi:project:Default Project:workspace:dandi-prod:run_phase:*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+data "aws_iam_policy" "administrator_access" {
+  arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "tfc_policy_attachment" {
+  role       = aws_iam_role.tfc_role.name
+  policy_arn = data.aws_iam_policy.administrator_access.arn
+}


### PR DESCRIPTION
This should allow terraform cloud to authenticate with AWS via a direct trust relationship instead of relying on a manual token placed in the environment of TFC.

See
https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials#how-dynamic-credentials-work for documentation on how the dynamic credential system works.

This adds the infrastructure for doing this authentication but doesn't switch over to it yet, that can be done after merging.