### PR TITLE
Scope trailing delete policy to `blobs` prefix only

### DIFF
--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -308,7 +308,7 @@ data "aws_iam_policy_document" "dandiset_bucket_policy" {
 
 
 # S3 lifecycle policy that permanently deletes objects with delete markers
-# after 30 days.
+# after 30 days. Note, this only applies to objects with the `blobs/` prefix.
 resource "aws_s3_bucket_lifecycle_configuration" "expire_deleted_objects" {
   # Must have bucket versioning enabled first
   depends_on = [aws_s3_bucket_versioning.dandiset_bucket]
@@ -320,7 +320,11 @@ resource "aws_s3_bucket_lifecycle_configuration" "expire_deleted_objects" {
   # Based on https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-configuration-examples.html#lifecycle-config-conceptual-ex7
   rule {
     id = "ExpireOldDeleteMarkers"
-    filter {}
+    filter {
+      # We only want to expire objects with the `blobs/` prefix, i.e. Asset Blobs.
+      # Other objects in this bucket are not subject to this lifecycle policy.
+      prefix = "blobs/"
+    }
 
     # Expire objects with delete markers after 30 days
     noncurrent_version_expiration {


### PR DESCRIPTION
Addresses https://github.com/dandi/dandi-infrastructure/pull/186#discussion_r1793671893.

Currently, the trailing delete lifecycle policy applies to the entire bucket. This PR updates it to only apply to the `blobs/` prefix, i.e. the prefix where asset blobs are stored. With this change, other objects in the bucket such as Zarr data and manifest files will not be impacted by the lifecycle policy.