### PR TITLE
Manifest file garbage collection

### DIFF
--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -344,7 +344,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "expire_noncurrent_manifest_fil
   # Must have bucket versioning enabled first
   depends_on = [aws_s3_bucket_versioning.dandiset_bucket]
 
-  count = var.versioning ? 1 : 0
+  count = var.versioning && var.enable_manifest_file_expiration ? 1 : 0
 
   bucket = aws_s3_bucket.dandiset_bucket.id
 

--- a/terraform/modules/dandiset_bucket/variables.tf
+++ b/terraform/modules/dandiset_bucket/variables.tf
@@ -34,3 +34,10 @@ variable "log_bucket_name" {
   type        = string
   description = "The name of the log bucket."
 }
+
+# TODO: remove this after it's ready to be enabled in production
+variable "enable_manifest_file_expiration" {
+  type        = bool
+  description = "Whether or not to enable expiration of manifest files."
+  default     = false
+}

--- a/terraform/staging_bucket.tf
+++ b/terraform/staging_bucket.tf
@@ -10,6 +10,7 @@ module "staging_dandiset_bucket" {
     aws         = aws
     aws.project = aws
   }
+  enable_manifest_file_expiration = true
 }
 
 module "staging_embargo_bucket" {


### PR DESCRIPTION
Closes #192.

Configures an S3 lifecycle rule to cap the number of noncurrent versions of manifest files to 1. See #192 for the rationale behind this rule.

Note - this only enables it in staging. After merging and verifying that it works correctly, I'll make a follow up PR enabling it for the production bucket.