### PR TITLE
Fix `noncurrent_version_expiration`

### DIFF
--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -357,9 +357,11 @@ resource "aws_s3_bucket_lifecycle_configuration" "expire_noncurrent_manifest_fil
       prefix = "dandisets/"
     }
 
-    # Only keep 1 noncurrent version of manifest files
     noncurrent_version_expiration {
+      # keep most recent noncurrent version indefinitely
       newer_noncurrent_versions = 1
+      # delete all other noncurrent versions after 1 day
+      noncurrent_days = 1
     }
 
     # Also delete any delete markers associated with the expired object


### PR DESCRIPTION
Follow up to #199 
[The apply from that PR failed ](https://app.terraform.io/app/dandi/dandi-prod/runs/run-YYwvSw99qE78Vck4) because the `noncurrent_days` field is actually mandatory. The AWS Terraform provider docs are incorrect, see https://github.com/hashicorp/terraform-provider-aws/issues/35328.

The AWS Console UI also confirms this -
![Screenshot from 2025-01-06 21-04-55](https://github.com/user-attachments/assets/1f059271-656c-499c-b6a0-a5cccf385fef)
