### PR TITLE
Add google-site-verification proof to TXT record

### DIFF
--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -71,7 +71,7 @@ resource "aws_route53_record" "email" {
   ]
 }
 
-resource "aws_route53_record" "txt_record" {
+resource "aws_route53_record" "email-spf" {
   zone_id = aws_route53_zone.dandi.zone_id
   name    = "" # apex
   type    = "TXT"

--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -71,12 +71,15 @@ resource "aws_route53_record" "email" {
   ]
 }
 
-resource "aws_route53_record" "email-spf" {
+resource "aws_route53_record" "txt_record" {
   zone_id = aws_route53_zone.dandi.zone_id
   name    = "" # apex
   type    = "TXT"
   ttl     = "300"
-  records = ["v=spf1 include:spf.improvmx.com ~all"]
+  records = [
+    "v=spf1 include:spf.improvmx.com ~all",
+    "google-site-verification=PRleUQ6hPcZFE9qVEQ0koOrCWMNwnMHz7QXWV5UDpFU",
+  ]
 }
 
 resource "aws_route53_record" "bluesky" {


### PR DESCRIPTION
This is needed to use [Google search console](https://search.google.com/search-console/about) for purposes such as https://github.com/dandi/dandi-archive/issues/2199.

Note that I made the change to the TXT record manually, and this PR catches the TF state up to the change I made (hence, the plan should show no changes).