### PR TITLE
Rename `staging` to `sandbox`

### DIFF
--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -18,12 +18,12 @@ resource "aws_route53_record" "gui" {
   records = ["75.2.60.5"] # Netlify's load balancer, which will proxy to our app
 }
 
-resource "aws_route53_record" "gui-staging" {
+resource "aws_route53_record" "sandbox" {
   zone_id = aws_route53_zone.dandi.zone_id
-  name    = "gui-staging"
+  name    = "sandbox"
   type    = "CNAME"
   ttl     = "300"
-  records = ["gui-staging-dandiarchive-org.netlify.com"]
+  records = ["sandbox-dandiarchive-org.netlify.com"]
 }
 
 resource "aws_route53_record" "www" {

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -5,10 +5,10 @@ module "api_staging" {
   source  = "kitware-resonant/resonant/heroku"
   version = "1.1.1"
 
-  project_slug     = "dandi-api-staging"
+  project_slug     = "dandi-api-sandbox"
   heroku_team_name = data.heroku_team.dandi.name
   route53_zone_id  = aws_route53_zone.dandi.zone_id
-  subdomain_name   = "api-staging"
+  subdomain_name   = "api-sandbox"
 
   heroku_web_dyno_size    = "basic"
   heroku_worker_dyno_size = "basic"
@@ -19,9 +19,9 @@ module "api_staging" {
   heroku_web_dyno_quantity    = 1
   heroku_worker_dyno_quantity = 1
 
-  django_default_from_email          = "admin@api-staging.dandiarchive.org"
-  django_cors_origin_whitelist       = ["https://gui-staging.dandiarchive.org", "https://neurosift.app"]
-  django_cors_origin_regex_whitelist = ["^https:\\/\\/[0-9a-z\\-]+--gui-staging-dandiarchive-org\\.netlify\\.app$"]
+  django_default_from_email          = "admin@api-sandbox.dandiarchive.org"
+  django_cors_origin_whitelist       = ["https://sandbox.dandiarchive.org", "https://neurosift.app"]
+  django_cors_origin_regex_whitelist = ["^https:\\/\\/[0-9a-z\\-]+--sandbox-dandiarchive-org\\.netlify\\.app$"]
 
   additional_django_vars = {
     DJANGO_CONFIGURATION                           = "HerokuStagingConfiguration"
@@ -38,8 +38,8 @@ module "api_staging" {
     DJANGO_SENTRY_DSN                              = data.sentry_key.this.dsn_public
     DJANGO_SENTRY_ENVIRONMENT                      = "staging"
     DJANGO_CELERY_WORKER_CONCURRENCY               = "2"
-    DJANGO_DANDI_WEB_APP_URL                       = "https://gui-staging.dandiarchive.org"
-    DJANGO_DANDI_API_URL                           = "https://api-staging.dandiarchive.org"
+    DJANGO_DANDI_WEB_APP_URL                       = "https://sandbox.dandiarchive.org"
+    DJANGO_DANDI_API_URL                           = "https://api-sandbox.dandiarchive.org"
     DJANGO_DANDI_JUPYTERHUB_URL                    = "https://hub.dandiarchive.org/"
     DJANGO_DANDI_DEV_EMAIL                         = var.dev_email
     DJANGO_DANDI_ADMIN_EMAIL                       = "info@dandiarchive.org"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -5,7 +5,7 @@ variable "doi_api_password" {
 
 variable "test_doi_api_password" {
   type        = string
-  description = "The password for the Datacite Test API, used to mint new DOIs on staging during publish."
+  description = "The password for the Datacite Test API, used to mint new DOIs on sandbox during publish."
 }
 
 variable "dev_email" {


### PR DESCRIPTION
@waxlamp With these changes, I was only renaming the user facing URLs and did not change the variables with the term `staging` in the AWS S3 bucket, Heroku, Sentry, etc.  Let me know if you feel that we should change all `staging` references to `sandbox`.  It would certainly reduce confusion in the long-term but would require a significant amount of work right now.