### PR TITLE
Remove analytics worker + associated IAM policies

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -57,13 +57,6 @@ resource "heroku_formation" "api_checksum_worker" {
   quantity = 1
 }
 
-resource "heroku_formation" "api_analytics_worker" {
-  app_id   = module.api.heroku_app_id
-  type     = "analytics-worker"
-  size     = "standard-1x"
-  quantity = 1
-}
-
 data "aws_iam_user" "api" {
   user_name = module.api.heroku_iam_user_id
 }

--- a/terraform/modules/dandiset_bucket/log_bucket.tf
+++ b/terraform/modules/dandiset_bucket/log_bucket.tf
@@ -20,24 +20,6 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "log_bucket" {
 
 data "aws_iam_policy_document" "dandiset_log_bucket_policy" {
   statement {
-    resources = [
-      "${aws_s3_bucket.log_bucket.arn}",
-      "${aws_s3_bucket.log_bucket.arn}/*",
-    ]
-
-    actions = [
-      # Needed for the app to process logs for collecting download analytics
-      "s3:GetObject",
-      "s3:ListBucket",
-    ]
-
-    principals {
-      type        = "AWS"
-      identifiers = [var.heroku_user.arn]
-    }
-  }
-
-  statement {
     sid       = "S3ServerAccessLogsPolicy"
     effect    = "Allow"
     resources = ["${aws_s3_bucket.log_bucket.arn}/*"]

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -56,13 +56,6 @@ resource "heroku_formation" "api_staging_checksum_worker" {
   quantity = 1
 }
 
-resource "heroku_formation" "api_staging_analytics_worker" {
-  app_id   = module.api_staging.heroku_app_id
-  type     = "analytics-worker"
-  size     = "basic"
-  quantity = 1
-}
-
 data "aws_iam_user" "api_staging" {
   user_name = module.api_staging.heroku_iam_user_id
 }


### PR DESCRIPTION
With https://github.com/dandi/dandi-archive/pull/2425, we no longer need the extra celery worker or extra IAM policies to grant the Heroku user access to the logging bucket.