### PR TITLE
Add `sandbox.dandiarchive.org` subdomain (web client only)

### DIFF
--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -26,6 +26,14 @@ resource "aws_route53_record" "gui-staging" {
   records = ["gui-staging-dandiarchive-org.netlify.com"]
 }
 
+resource "aws_route53_record" "gui-sandbox" {
+  zone_id = aws_route53_zone.dandi.zone_id
+  name    = "sandbox"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["sandbox-dandiarchive-org.netlify.com"]
+}
+
 resource "aws_route53_record" "www" {
   zone_id = aws_route53_zone.dandi.zone_id
   name    = "www"

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -20,7 +20,7 @@ module "api_staging" {
   heroku_worker_dyno_quantity = 1
 
   django_default_from_email          = "admin@api-staging.dandiarchive.org"
-  django_cors_origin_whitelist       = ["https://gui-staging.dandiarchive.org", "https://neurosift.app"]
+  django_cors_origin_whitelist       = ["https://sandbox.dandiarchive.org", "https://gui-staging.dandiarchive.org", "https://neurosift.app"]
   django_cors_origin_regex_whitelist = ["^https:\\/\\/[0-9a-z\\-]+--gui-staging-dandiarchive-org\\.netlify\\.app$"]
 
   additional_django_vars = {


### PR DESCRIPTION
https://github.com/dandi/dandi-archive/issues/1030

This is the first in a series of PRs to fully rename the `staging` deployment to `sandbox`. All this does is add a new subdomain/CNAME record, `sandbox.dandiarchive.org`, and points it at `sandbox-dandiarchive-org.netlify.com`

Separately, I've created a new Netlify site for this. It's currently accessible at https://sandbox-dandiarchive-org.netlify.app/, but once this PR is merged and applied it will be https://sandbox.dandiarchive.org. 

Once we've confirmed that the change works as expected, I'll update the old `gui-staging-dandiarchive-org` Netlify site to simply redirect to the sandbox one and then work on switching the API server as well.