### PR TITLE
Configure DNS for netlify api-staging redirector

### DIFF
--- a/terraform/domain_sandbox.tf
+++ b/terraform/domain_sandbox.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "ns_sandbox" {
   records = aws_route53_zone.dandi_sandbox.name_servers
 }
 
-# Legacy, to be deleted
+# TODO: remove these once we don't need the redirects anymore.
 resource "aws_route53_record" "gui-staging" {
   # Intentionally pointing to the production zone
   zone_id = aws_route53_zone.dandi.zone_id
@@ -19,6 +19,14 @@ resource "aws_route53_record" "gui-staging" {
   type    = "CNAME"
   ttl     = "300"
   records = ["gui-staging-dandiarchive-org.netlify.com"]
+}
+resource "aws_route53_record" "api-staging" {
+  # Intentionally pointing to the production zone
+  zone_id = aws_route53_zone.dandi.zone_id
+  name    = "api-staging"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["api-staging-dandiarchive-org.netlify.com"]
 }
 
 resource "aws_route53_record" "gui_sandbox" {

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -107,18 +107,3 @@ resource "heroku_pipeline_coupling" "production" {
   pipeline = heroku_pipeline.dandi_pipeline.id
   stage    = "production"
 }
-
-# TODO: these are the old staging resources that we are moving to sandbox.
-# They will be removed once the sandbox is fully operational and the staging
-# resources are no longer needed.
-resource "heroku_domain" "staging_old" {
-  app_id   = module.api_sandbox_heroku.app_id
-  hostname = "api-staging.dandiarchive.org"
-}
-resource "aws_route53_record" "staging_old" {
-  zone_id = aws_route53_zone.dandi.zone_id
-  name    = "api-staging"
-  type    = "CNAME"
-  ttl     = "300"
-  records = [heroku_domain.staging_old.cname]
-}


### PR DESCRIPTION
This is a prerequisite for https://github.com/dandi/dandi-archive/pull/2449. I've created the `api-staging-dandiarchive-org` app on Netlify and pointed it at the `redirector/` directory.