### PR TITLE
Import new heroku_formation resources

### DIFF
--- a/terraform/imports.tf
+++ b/terraform/imports.tf
@@ -1,9 +1,14 @@
 import {
-  to = module.api_sandbox.aws_route53_record.heroku
-  id = "Z02063701JNV8GCOUJIZZ_api.sandbox_CNAME"
+  to = module.api_sandbox.module.heroku.heroku_formation.heroku_web
+  id = "dandi-api-staging:web"
 }
 
 import {
-  to = module.api_sandbox.module.heroku.heroku_domain.heroku
-  id = "dandi-api-staging:api.sandbox.dandiarchive.org"
+  to = module.api_sandbox.module.heroku.heroku_formation.heroku_worker
+  id = "dandi-api-staging:worker"
+}
+
+import {
+  to = heroku_formation.api_staging_checksum_worker
+  id = "dandi-api-staging:checksum-worker"
 }


### PR DESCRIPTION
https://github.com/dandi/dandi-archive/pull/2466 inadvertently deleted the Heroku "formation" objects (i.e. the dyno types) by excluding the Procfile from the sdist pushed to Heroku, causing them to get deleted and recreated. 

Because we waited until the hatchling set up was fixed to cut a release, this only affects the staging deployment and not production.