### PR TITLE
Disable ACLs on the S3 bucket and require object ownership

### DIFF
--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -68,17 +68,8 @@ resource "aws_s3_bucket_ownership_controls" "dandiset_bucket" {
   bucket = aws_s3_bucket.dandiset_bucket.id
 
   rule {
-    object_ownership = "BucketOwnerPreferred"
+    object_ownership = "BucketOwnerEnforced"
   }
-}
-
-resource "aws_s3_bucket_acl" "dandiset_bucket" {
-  depends_on = [aws_s3_bucket_ownership_controls.dandiset_bucket]
-
-  bucket = aws_s3_bucket.dandiset_bucket.id
-
-  // Public access is granted via a bucket policy, not a canned ACL
-  acl = "private"
 }
 
 resource "aws_iam_user_policy" "dandiset_bucket_owner" {
@@ -117,21 +108,6 @@ data "aws_iam_policy_document" "dandiset_bucket_owner" {
       ]
 
       actions = ["s3:PutObject", "s3:PutObjectTagging"]
-    }
-  }
-
-  statement {
-    resources = [
-      "${aws_s3_bucket.dandiset_bucket.arn}",
-      "${aws_s3_bucket.dandiset_bucket.arn}/*",
-    ]
-
-    actions = ["s3:*"]
-
-    condition {
-      test     = "StringEquals"
-      variable = "s3:x-amz-acl"
-      values   = ["bucket-owner-full-control"]
     }
   }
 }
@@ -219,11 +195,6 @@ data "aws_iam_policy_document" "dandiset_bucket_policy" {
         values   = [data.aws_caller_identity.sponsored_account.account_id]
       }
       condition {
-        test     = "StringEquals"
-        variable = "s3:x-amz-acl"
-        values   = ["bucket-owner-full-control"]
-      }
-      condition {
         test     = "ArnLike"
         variable = "aws:SourceArn"
         values   = [aws_s3_bucket.dandiset_bucket.arn]
@@ -242,26 +213,6 @@ data "aws_iam_policy_document" "dandiset_bucket_policy" {
       "s3:List*",
       "s3:Delete*",
     ]
-
-    principals {
-      type        = "AWS"
-      identifiers = [var.heroku_user.arn]
-    }
-  }
-
-  statement {
-    resources = [
-      "${aws_s3_bucket.dandiset_bucket.arn}",
-      "${aws_s3_bucket.dandiset_bucket.arn}/*",
-    ]
-
-    actions = ["s3:*"]
-
-    condition {
-      test     = "StringEquals"
-      variable = "s3:x-amz-acl"
-      values   = ["bucket-owner-full-control"]
-    }
 
     principals {
       type        = "AWS"


### PR DESCRIPTION
Closes #137 

ACLs are deprecated by AWS, in favor of bucket policies.

Additionally, this allows us to set `BucketOwnerEnforced` Object Ownership. Accordingly, ACLs set by by other AWS accounts are ignored, so we no longer have to worry about `bucket-owner-full-control` being set.

See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html