### PR TITLE
Encode `aws_s3_bucket_public_access_block` in TF

### DIFF
--- a/terraform/imports.tf
+++ b/terraform/imports.tf
@@ -1,0 +1,19 @@
+import {
+  to = module.sponsored_dandiset_bucket.aws_s3_bucket_public_access_block.dandiset_bucket
+  id = "dandiarchive"
+}
+
+import {
+  to = module.sponsored_embargo_bucket.aws_s3_bucket_public_access_block.dandiset_bucket
+  id = "dandiarchive-embargo"
+}
+
+import {
+  to = module.staging_dandiset_bucket.aws_s3_bucket_public_access_block.dandiset_bucket
+  id = "dandi-api-staging-dandisets"
+}
+
+import {
+  to = module.staging_embargo_bucket.aws_s3_bucket_public_access_block.dandiset_bucket
+  id = "dandi-api-staging-embargo-dandisets"
+}

--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -23,6 +23,17 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "dandiset_bucket" 
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "dandiset_bucket" {
+  bucket = aws_s3_bucket.dandiset_bucket.id
+
+  # Allows public access to the bucket (if applicable)
+  # S3's default is to block all public access
+  block_public_policy     = !var.public
+  restrict_public_buckets = !var.public
+  block_public_acls       = !var.public
+  ignore_public_acls      = !var.public
+}
+
 resource "aws_s3_bucket_cors_configuration" "dandiset_bucket" {
   bucket = aws_s3_bucket.dandiset_bucket.id
 


### PR DESCRIPTION
Docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block

It seems this was configured manually in the AWS console, or possibly by AWS when they gave us the open data bucket, and was never encoded into Terraform.