### PR TITLE
Handle emails sent to info@sandbox.dandiarchive.org

### DIFF
--- a/terraform/domain_sandbox.tf
+++ b/terraform/domain_sandbox.tf
@@ -36,3 +36,22 @@ resource "aws_route53_record" "gui_sandbox" {
   ttl     = "300"
   records = ["75.2.60.5"] # Netlify's load balancer, which will proxy to our app
 }
+
+resource "aws_route53_record" "sandbox_email" {
+  zone_id = aws_route53_zone.dandi_sandbox.zone_id
+  name    = "" # apex
+  type    = "MX"
+  ttl     = "300"
+  records = [
+    "10 mx1.improvmx.com.",
+    "20 mx2.improvmx.com.",
+  ]
+}
+
+resource "aws_route53_record" "sandbox_email_spf" {
+  zone_id = aws_route53_zone.dandi_sandbox.zone_id
+  name    = "" # apex
+  type    = "TXT"
+  ttl     = "300"
+  records = ["v=spf1 include:spf.improvmx.com ~all"]
+}

--- a/terraform/email_forwarding.tf
+++ b/terraform/email_forwarding.tf
@@ -26,3 +26,13 @@ resource "improvmx_email_forward" "community" {
   alias_name        = "community"
   destination_email = "kabi@mit.edu,roni.choudhury@kitware.com,satra@mit.edu,yoh@onerussian.com"
 }
+
+resource "improvmx_domain" "sandbox" {
+  domain = "sandbox.dandiarchive.org"
+}
+
+resource "improvmx_email_forward" "sandbox_info" {
+  domain            = improvmx_domain.sandbox.domain
+  alias_name        = "info"
+  destination_email = "dandi@mit.edu"
+}


### PR DESCRIPTION
This PR adds the Route53 and ImprovMX entries needed to route emails sent to info@sandbox.dandiarchive.org to the DANDI team.

@kabilar, I've intentionally only handled `info`, rather than `help`, `team`, and `community` as is the case for dandiarchive.org. My reasoning is that `info` is the only one that people might plausibly write to, since it's the "from" address for the automated emails sent to users. `help` might be something people reach for (especially if it's linked from the client), but `team` and `community` should (IMO) not be duplicated to sandbox, simply to avoid confusion.

If you feel differently, we can capture what we want in this PR (or a followup).