### PR TITLE
Add import block to capture email forward resource

### DIFF
--- a/terraform/email_forwarding.tf
+++ b/terraform/email_forwarding.tf
@@ -36,3 +36,8 @@ resource "improvmx_email_forward" "sandbox_info" {
   alias_name        = "info"
   destination_email = "dandi@mit.edu"
 }
+
+import {
+  to = improvmx_email_forward.sandbox_info
+  id = "sandbox.dandiarchive.org_info"
+}


### PR DESCRIPTION
When the plan ran without this block, the system attempted to create the email forward resource, did so, but then apparently failed, leaving the system in a broken state: the resource was created but the system did not recognize it, leaving future plans attempting to create the resource again.

This solves the problem by just importing the resource. The next commit will revert this change, as though the problem never occurred.