### PR TITLE
Revert "Add import block to capture email forward resource"

### DIFF
--- a/terraform/email_forwarding.tf
+++ b/terraform/email_forwarding.tf
@@ -36,8 +36,3 @@ resource "improvmx_email_forward" "sandbox_info" {
   alias_name        = "info"
   destination_email = "dandi@mit.edu"
 }
-
-import {
-  to = improvmx_email_forward.sandbox_info
-  id = "sandbox.dandiarchive.org_info"
-}


### PR DESCRIPTION
This reverts commit 577af51440f029d3d1b16a32298a16ceed7a0c14.

This removes the import block that is no longer needed after the import operation succeeded.

See https://github.com/dandi/dandi-infrastructure/pull/275 and https://github.com/dandi/dandi-infrastructure/pull/274 for context.