### PR TITLE
Update admin email for sandbox environment

### DIFF
--- a/terraform/staging.tf
+++ b/terraform/staging.tf
@@ -48,7 +48,7 @@ module "api_sandbox_heroku" {
     # These may be removed in the future
     DJANGO_DANDI_DANDISETS_BUCKET_NAME = module.staging_dandiset_bucket.bucket_name
     DJANGO_DANDI_DEV_EMAIL             = var.dev_email
-    DJANGO_DANDI_ADMIN_EMAIL           = "info@dandiarchive.org"
+    DJANGO_DANDI_ADMIN_EMAIL           = "info@sandbox.dandiarchive.org"
   }
   sensitive_config_vars = {
     AWS_SECRET_ACCESS_KEY         = aws_iam_access_key.api_sandbox_heroku_user.secret


### PR DESCRIPTION
For the sandbox server, the `rejected_user_message.txt` email template sends the message `From: <info@sandbox.dandiarchive.org>` and `To: <info@dandiarchive.org>, <user's email>`.  So I am proposing this change to be consistent.